### PR TITLE
ci: add GitHub Pages workflow to build and publish great-docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,102 @@
+name: CI Docs
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build-docs:
+    name: "Build Docs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Full history for accurate page timestamps
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install package and dependencies
+        run: |
+          python -m pip install poetry
+          poetry install
+          poetry run pip install great-docs
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Build docs
+        run: poetry run great-docs build
+
+      - name: Save docs artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-html
+          path: great-docs/_site
+
+  publish-docs:
+    name: "Publish Docs"
+    runs-on: ubuntu-latest
+    needs: "build-docs"
+    if: github.ref == 'refs/heads/master'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: docs-html
+          path: great-docs/_site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: great-docs/_site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+  preview-docs:
+    name: "Preview Docs"
+    runs-on: ubuntu-latest
+    needs: "build-docs"
+    if: github.event_name == 'pull_request'
+    permissions:
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: docs-html
+          path: great-docs/_site
+
+      # Start deployment
+      - name: Configure pull release name
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "RELEASE_NAME=pr-${{ github.event.number }}" >> $GITHUB_ENV
+
+      - name: Configure branch release name
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          # use branch name, but replace slashes. E.g. feat/a -> feat-a
+          echo "RELEASE_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
+
+      # Deploy
+      - name: Create Github Deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.RELEASE_NAME }}
+          ref: ${{ github.head_ref }}
+          logs: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,3 +100,14 @@ jobs:
           env: ${{ env.RELEASE_NAME }}
           ref: ${{ github.head_ref }}
           logs: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      # Always close the deployment so it doesn't sit in pending forever.
+      - name: Finish Github Deployment
+        uses: bobheadxi/deployments@v1
+        if: always() && steps.deployment.outputs.deployment_id != ''
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          env: ${{ steps.deployment.outputs.env }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/index.qmd
+++ b/index.qmd
@@ -52,40 +52,22 @@ tidysdmx wraps [pysdmx](https://py.sdmx.io) with higher-level helpers tuned for 
 
 ```{=html}
 <div class="gd-cta-grid">
-  <a href="user_guide/03-end-to-end-workflow.html" class="gd-cta-card">
-    <span class="gd-cta-icon">🛠️</span>
-    <span class="gd-cta-title">End-to-end workflow</span>
-    <span class="gd-cta-desc">Walk through the full WB ASPIRE pipeline — from raw CSVs to validated SDMX-ML.</span>
-    <span class="gd-cta-arrow">→</span>
-  </a>
   <a href="user_guide/01-installation.html" class="gd-cta-card">
     <span class="gd-cta-icon">📦</span>
     <span class="gd-cta-title">Installation</span>
     <span class="gd-cta-desc">Install tidysdmx with pip or Poetry, set up an FMR client, and sanity-check.</span>
     <span class="gd-cta-arrow">→</span>
   </a>
-  <a href="recipes/index.html" class="gd-cta-card">
-    <span class="gd-cta-icon">🍳</span>
-    <span class="gd-cta-title">Recipes</span>
-    <span class="gd-cta-desc">Bite-sized snippets for common tasks: fetch a schema, validate, export XML.</span>
+  <a href="user_guide/02-quick-start.html" class="gd-cta-card">
+    <span class="gd-cta-icon">🚀</span>
+    <span class="gd-cta-title">Quick start</span>
+    <span class="gd-cta-desc">The smallest end-to-end tidysdmx example — tidy DataFrame in, validated output out.</span>
     <span class="gd-cta-arrow">→</span>
   </a>
   <a href="reference/index.html" class="gd-cta-card">
     <span class="gd-cta-icon">⚙️</span>
     <span class="gd-cta-title">API reference</span>
     <span class="gd-cta-desc">Every public function, parameter, and return type — auto-generated from docstrings.</span>
-    <span class="gd-cta-arrow">→</span>
-  </a>
-  <a href="user_guide/08-llms-and-agents.html" class="gd-cta-card">
-    <span class="gd-cta-icon">🤖</span>
-    <span class="gd-cta-title">For LLMs &amp; agents</span>
-    <span class="gd-cta-desc">Download <code>llms.txt</code>, <code>llms-full.txt</code>, and the agent skill bundle.</span>
-    <span class="gd-cta-arrow">→</span>
-  </a>
-  <a href="user_guide/04-sdmx-concepts.html" class="gd-cta-card">
-    <span class="gd-cta-icon">📚</span>
-    <span class="gd-cta-title">SDMX concepts</span>
-    <span class="gd-cta-desc">A quick orientation to DSDs, codelists, structure maps, and dataflows.</span>
     <span class="gd-cta-arrow">→</span>
   </a>
 </div>

--- a/user_guide/00-introduction.qmd
+++ b/user_guide/00-introduction.qmd
@@ -31,12 +31,8 @@ If you already know pysdmx, you can think of tidysdmx as a set of opinionated co
 
 - [Installation](01-installation.qmd) — install with pip or Poetry and verify your environment.
 - [Quick start](02-quick-start.qmd) — the smallest end-to-end example.
-- [End-to-end workflow](03-end-to-end-workflow.qmd) — a full walkthrough of the iterative-development pipeline, mirroring the [`DEV-pipeline-iterative-development-wb-template.ipynb`](https://github.com/WB-DECIS/tidysdmx/blob/dev/notebooks/tidysdmx/DEV-pipeline-iterative-development-wb-template.ipynb) notebook.
-- [SDMX concepts](04-sdmx-concepts.qmd) — a short refresher on DSDs, codelists, structure maps, and friends.
-- [FMR integration](05-fmr-integration.qmd) — working with the Fusion Metadata Registry from Python.
-- [Mapping templates](06-mapping-templates.qmd) — the World Bank Excel mapping workbook format.
-- [Validation](07-validation.qmd) — catching errors before you upload.
-- [LLMs & agents](08-llms-and-agents.qmd) — downloadable `llms.txt`, `llms-full.txt`, and skill bundle.
+
+More chapters — end-to-end workflow, SDMX concepts, FMR integration, mapping templates, validation, and LLM/agent artefacts — are in progress and will be linked here as they land.
 
 ## Status
 

--- a/user_guide/01-installation.qmd
+++ b/user_guide/01-installation.qmd
@@ -54,11 +54,11 @@ from tidysdmx import (
 )
 ```
 
-If the imports succeed, you're ready to go. Continue to the [quick start](02-quick-start.qmd) or jump straight to the [end-to-end workflow](03-end-to-end-workflow.qmd).
+If the imports succeed, you're ready to go. Continue to the [quick start](02-quick-start.qmd).
 
 ## Optional: connect to FMR
 
-Most real-world workflows fetch a dissemination schema from a Fusion Metadata Registry. The `pysdmx` FMR client is bundled with tidysdmx; see [FMR integration](05-fmr-integration.qmd) for authentication, environments, and TLS troubleshooting.
+Most real-world workflows fetch a dissemination schema from a Fusion Metadata Registry. The `pysdmx` FMR client is bundled with tidysdmx and can be instantiated directly:
 
 ```python
 import pysdmx as px

--- a/user_guide/02-quick-start.qmd
+++ b/user_guide/02-quick-start.qmd
@@ -6,7 +6,7 @@ tags: [Getting Started, Workflow]
 
 # Quick start
 
-This page shows the smallest possible tidysdmx pipeline: tidy DataFrame in, validated SDMX-ready output out. For the full iterative-development walkthrough (with FMR fetch, Excel mapping, and XML export) see the [end-to-end workflow](03-end-to-end-workflow.qmd).
+This page shows the smallest possible tidysdmx pipeline: tidy DataFrame in, validated SDMX-ready output out. A full iterative-development walkthrough (with FMR fetch, Excel mapping, and XML export) is in progress.
 
 ## 1. Describe your tidy raw data as a schema
 
@@ -46,7 +46,7 @@ assert errors.empty
 
 ## 3. Apply a structure map (when you have one)
 
-With a `StructureMap` from pysdmx (or one built via [`build_structure_map_from_template_wb`](06-mapping-templates.qmd)):
+With a `StructureMap` from pysdmx (or one built via `build_structure_map_from_template_wb`):
 
 ```python
 from tidysdmx import map_structures, standardize_output
@@ -65,6 +65,5 @@ out = standardize_output(
 
 ## Where to next?
 
-- The [end-to-end workflow](03-end-to-end-workflow.qmd) walks through every step in detail with a real World Bank dataset.
-- The [recipes](../recipes/index.html) collect copy-pasteable solutions to common tasks.
 - The [API reference](../reference/index.html) documents every public function.
+- A full end-to-end workflow walkthrough and recipe collection are in progress.


### PR DESCRIPTION
Adds .github/workflows/docs.yml generated via `great-docs setup-github-pages`. The workflow builds the documentation site with Quarto + great-docs on every push to master and PR, and deploys to GitHub Pages on master.

To activate, enable Pages in repo Settings -> Pages with Source set to "GitHub Actions".