### PR TITLE
Validate representation list lengths and fix catch-all regex matching

### DIFF
--- a/src/tidysdmx/mapping.py
+++ b/src/tidysdmx/mapping.py
@@ -167,6 +167,10 @@ def apply_component_map(
 ) -> pd.DataFrame:
     """Apply a single ComponentMap with a RepresentationMap to a DataFrame.
 
+    Missing source values (NaN/None) remain unmapped: they are never matched
+    by regex value maps or the catch-all (``"regex:.*"``) and yield NaN in the
+    target column.
+
     Args:
         df: Source data.
         component_map: ComponentMap with source, target, and values.
@@ -208,7 +212,9 @@ def apply_component_map(
                     return vm.target
             return None
 
-        unmatched = mapped.isna()
+        # Missing source values stay unmapped: str(NaN) is "nan", which a
+        # regex (especially the catch-all "regex:.*") would otherwise match.
+        unmatched = mapped.isna() & result_df[source_col].notna()
         if unmatched.any():
             mapped = mapped.astype(object)
             mapped.loc[unmatched] = result_df.loc[unmatched, source_col].map(
@@ -240,6 +246,10 @@ def apply_multi_component_map(
     then any pure catch-all (``"regex:.*"`` for every component) last. The first
     matching rule wins. Patterns prefixed with ``"regex:"`` are matched using
     ``re.fullmatch``.
+
+    Rows with a missing value (NaN/None) in any source column remain
+    unmapped: they are never matched by any rule (including the catch-all)
+    and yield NaN in the target column.
 
     Only the first target column is used; multi-target MultiComponentMaps
     are not supported.
@@ -273,6 +283,10 @@ def apply_multi_component_map(
     rules.sort(key=lambda rule: _value_map_rank(rule["patterns"]))
 
     def match_row(row):
+        # Missing source values stay unmapped: str(NaN) is "nan", which a
+        # regex (especially the catch-all "regex:.*") would otherwise match.
+        if row.isna().any():
+            return None
         for rule in rules:
             match = True
             for col_val, pattern in zip(row, rule["patterns"], strict=True):

--- a/src/tidysdmx/structures.py
+++ b/src/tidysdmx/structures.py
@@ -565,8 +565,12 @@ def build_multi_representation_map(
         agency: Agency maintaining the map. Defaults to "FAKE_AGENCY".
         id: Identifier for the map.
         name: Name of the map.
-        source_cls: URNs/IDs for source codelists/types.
-        target_cls: URNs/IDs for target codelists/types.
+        source_cls: URNs/IDs for source codelists/types, one per source
+            column. When omitted, each source is represented as
+            ``DataType.STRING``.
+        target_cls: URNs/IDs for target codelists/types, one per target
+            column. When omitted, each target is represented as
+            ``DataType.STRING``.
         version: Version of the map. Defaults to "1.0".
         description: Description of the map.
         source_cols: Source columns. Defaults to ["source"].
@@ -584,7 +588,9 @@ def build_multi_representation_map(
         The constructed MultiRepresentationMap object.
 
     Raises:
-        ValueError: If DataFrame is empty or columns are missing.
+        ValueError: If DataFrame is empty, columns are missing, or the length
+            of ``source_cls``/``target_cls`` does not match the number of
+            source/target columns.
         TypeError: If non-string data is found in source/target columns.
     """
     if df.empty:
@@ -599,6 +605,18 @@ def build_multi_representation_map(
     missing_cols = required_cols - set(df.columns)
     if missing_cols:
         raise ValueError(f"Missing required columns: {missing_cols}")
+
+    # Representation refs, when provided, must align with the mapped columns
+    if source_cls is not None and len(source_cls) != len(_source_cols):
+        raise ValueError(
+            f"Length of source_cls ({len(source_cls)}) must match the number "
+            f"of source columns ({len(_source_cols)})."
+        )
+    if target_cls is not None and len(target_cls) != len(_target_cols):
+        raise ValueError(
+            f"Length of target_cls ({len(target_cls)}) must match the number "
+            f"of target columns ({len(_target_cols)})."
+        )
 
     # Validate data types (String check)
     for col in _source_cols + _target_cols:
@@ -627,10 +645,10 @@ def build_multi_representation_map(
         agency=agency,
         source=[_resolve_representation_ref(s) for s in source_cls]
         if source_cls
-        else [str(DataType.STRING)],
+        else [str(DataType.STRING)] * len(_source_cols),
         target=[_resolve_representation_ref(t) for t in target_cls]
         if target_cls
-        else [str(DataType.STRING)],
+        else [str(DataType.STRING)] * len(_target_cols),
         maps=multi_value_maps,
         description=description,
         version=version,
@@ -1779,7 +1797,9 @@ def build_structure_map_from_template_wb(
     with contextlib.suppress(ValueError):
         rep_data = _parse_rep_mapping_sheet(mappings)
 
-    generated_maps: list[FixedValueMap | ImplicitComponentMap | ComponentMap] = []
+    generated_maps: list[
+        FixedValueMap | ImplicitComponentMap | ComponentMap | MultiComponentMap
+    ] = []
 
     # Track RepresentationMap IDs to avoid duplicates
     rep_map_counter = {}

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -254,6 +254,20 @@ class TestApplyComponentMap:
         result = apply_component_map(df, cm)
         assert list(result["REGION"]) == ["EU", "_Z"]
 
+    def test_na_source_not_caught_by_catch_all(self):
+        """Missing source values stay NaN instead of receiving the default."""
+        cm = self._component_map_with_catch_all(
+            [
+                ValueMap(source="FR", target="EU"),
+                ValueMap(source="regex:.*", target="_Z"),
+            ]
+        )
+        df = pd.DataFrame({"AREA": ["FR", np.nan, None]})
+
+        result = apply_component_map(df, cm)
+        assert result["REGION"].iloc[0] == "EU"
+        assert result["REGION"].iloc[1:].isna().all()
+
 
 class TestApplyMultiComponentMap:
     """Tests for apply_multi_component_map function."""
@@ -348,6 +362,22 @@ class TestApplyMultiComponentMap:
 
         result = apply_multi_component_map(df, mcm)
         assert list(result["URBANISATION"]) == ["RUR", "_Z"]
+
+    def test_na_source_not_caught_by_catch_all(self):
+        """Rows with any missing source value stay NaN, bypassing the catch-all."""
+        mcm = self._multi_map_with_catch_all(
+            [
+                MultiValueMap(source=["COL", "one"], target=["RUR"]),
+                MultiValueMap(source=["regex:.*", "regex:.*"], target=["_Z"]),
+            ]
+        )
+        df = pd.DataFrame(
+            {"AREA": ["COL", np.nan, "XYZ"], "NOTE": ["one", "one", None]}
+        )
+
+        result = apply_multi_component_map(df, mcm)
+        assert result["URBANISATION"].iloc[0] == "RUR"
+        assert result["URBANISATION"].iloc[1:].isna().all()
 
 
 class TestMapStructures:

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -1078,6 +1078,38 @@ class TestBuildMultiRepresentationMap:
         )
         assert result.urn is None
 
+    def test_default_representations_match_column_counts(self):
+        """Omitted source_cls/target_cls default to one String per column."""
+        df = pd.DataFrame(
+            {
+                "COUNTRY": ["DE", "CH"],
+                "CURRENCY": ["LC", "LC"],
+                "ISO_CURRENCY": ["EUR", "CHF"],
+            }
+        )
+        result = build_multi_representation_map(
+            df,
+            source_cols=["COUNTRY", "CURRENCY"],
+            target_cols=["ISO_CURRENCY"],
+            id="MRM1",
+        )
+        assert list(result.source) == [str(DataType.STRING)] * 2
+        assert list(result.target) == [str(DataType.STRING)]
+
+    def test_source_cls_length_mismatch_raises_value_error(self, sample_df):
+        """source_cls must have one entry per source column."""
+        with pytest.raises(ValueError, match="Length of source_cls"):
+            build_multi_representation_map(
+                sample_df, source_cls=["urn:a:cl", "urn:b:cl"]
+            )
+
+    def test_target_cls_length_mismatch_raises_value_error(self, sample_df):
+        """target_cls must have one entry per target column."""
+        with pytest.raises(ValueError, match="Length of target_cls"):
+            build_multi_representation_map(
+                sample_df, target_cls=["urn:a:cl", "urn:b:cl"]
+            )
+
 
 class TestBuildMultiComponentMap:
     """Tests for build_multi_component_map (N source components -> 1 target)."""
@@ -1168,6 +1200,17 @@ class TestBuildMultiComponentMap:
             id="MCM1",
         )
         assert len(cm.values.maps) == 2
+
+    def test_default_representations_one_per_component(self, multi_df):
+        """Omitted source_cls/target_cls yield one representation per component."""
+        cm = build_multi_component_map(
+            multi_df,
+            source_components=["COUNTRY", "CURRENCY"],
+            target_components=["ISO_CURRENCY"],
+            id="MCM1",
+        )
+        assert list(cm.values.source) == [str(DataType.STRING)] * 2
+        assert list(cm.values.target) == [str(DataType.STRING)]
 
     def test_exported_from_package(self):
         """build_multi_component_map is part of the public tidysdmx API."""


### PR DESCRIPTION
## Summary

This PR adds validation for representation class list lengths in multi-representation and multi-component map builders, and fixes a bug where missing source values were incorrectly matched by catch-all regex patterns.

## Key Changes

**Validation improvements:**
- `build_multi_representation_map()` now validates that `source_cls` and `target_cls` lists (when provided) have exactly one entry per source/target column, raising `ValueError` if lengths don't match
- Updated docstrings to clarify that omitted `source_cls`/`target_cls` default to one `DataType.STRING` per column
- Fixed default representation generation to create the correct number of `DataType.STRING` entries (was always creating 1, now creates N per column count)

**Mapping bug fix:**
- `apply_component_map()` and `apply_multi_component_map()` now correctly skip missing source values (NaN/None) when matching against regex patterns, including the catch-all (`"regex:.*"`)
- Previously, `str(NaN)` would be converted to the string `"nan"` and matched by regex patterns; now missing values remain unmapped and yield NaN in the target column
- Updated docstrings to document this behavior

## Implementation Details

- Added length validation checks in `build_multi_representation_map()` before processing representation references
- Modified default representation generation from `[str(DataType.STRING)]` to `[str(DataType.STRING)] * len(cols)` to match column counts
- In mapping functions, added `& result_df[source_col].notna()` and `if row.isna().any()` checks to exclude missing values from regex matching logic
- Updated type hint in `build_structure_map_from_template_wb()` to include `MultiComponentMap` in the generated maps list

## Tests Added

- `test_default_representations_match_column_counts()` — verifies correct number of default STRING representations
- `test_source_cls_length_mismatch_raises_value_error()` — validates source_cls length checking
- `test_target_cls_length_mismatch_raises_value_error()` — validates target_cls length checking
- `test_default_representations_one_per_component()` — verifies multi-component map defaults
- `test_na_source_not_caught_by_catch_all()` — verifies missing values bypass catch-all in both component and multi-component mapping

https://claude.ai/code/session_019NdJejrTF4SoL96wmynpaJ