### PR TITLE
fix(structures): make missing id/name fail validation, not typeguard

### DIFF
--- a/src/tidysdmx/structures.py
+++ b/src/tidysdmx/structures.py
@@ -559,9 +559,9 @@ def build_representation_map_from_df(
     Raises:
         ValueError: If required columns are missing.
         TypeError: If source or target columns contain non-string values.
-        ValidationError: If ``id``/``name`` resolve to an empty string, or
-            the DataFrame yields no value mappings (rule R003) — see
-            :mod:`tidysdmx.artefact_validation`.
+        ValidationError: If ``id``/``name`` are omitted or empty (rules
+            M001/M003), or the DataFrame yields no value mappings (rule
+            R003) — see :mod:`tidysdmx.artefact_validation`.
 
     Examples:
         >>> import pandas as pd
@@ -607,10 +607,12 @@ def build_representation_map_from_df(
         if (generate_urn and id)
         else None
     )
+    # None -> "" so omitted id/name fail the value builder's publish-readiness
+    # checks (M001/M003) instead of typeguard's stricter `str` annotation.
     return _build_representation_map(
-        id=id,
+        id=id or "",
         agency=agency,
-        name=name,
+        name=name or "",
         source=_resolve_representation_ref(source_cl),
         target=_resolve_representation_ref(target_cl),
         maps=value_maps,
@@ -621,9 +623,44 @@ def build_representation_map_from_df(
 
 
 @deprecated(replacement="build_representation_map_from_df")
-def build_representation_map(*args: object, **kwargs: object) -> RepresentationMap:
-    """Deprecated alias for :func:`build_representation_map_from_df`."""
-    return build_representation_map_from_df(*args, **kwargs)
+def build_representation_map(
+    df: pd.DataFrame,
+    agency: str = "FAKE_AGENCY",
+    id: str | None = None,
+    name: str | None = None,
+    source_cl: str | None = None,
+    target_cl: str | None = None,
+    version: str = "1.0",
+    description: str | None = None,
+    source_col: str = "source",
+    target_col: str = "target",
+    valid_from_col: str = "valid_from",
+    valid_to_col: str = "valid_to",
+    generate_urn: bool = True,
+    default_value: str | None = None,
+) -> RepresentationMap:
+    """Deprecated alias for :func:`build_representation_map_from_df`.
+
+    Mirrors that function's signature so ``help()``/IDE introspection keep
+    showing the real parameters during the deprecation window; see it for
+    the full documentation.
+    """
+    return build_representation_map_from_df(
+        df,
+        agency=agency,
+        id=id,
+        name=name,
+        source_cl=source_cl,
+        target_cl=target_cl,
+        version=version,
+        description=description,
+        source_col=source_col,
+        target_col=target_col,
+        valid_from_col=valid_from_col,
+        valid_to_col=valid_to_col,
+        generate_urn=generate_urn,
+        default_value=default_value,
+    )
 
 
 @typechecked
@@ -688,8 +725,8 @@ def build_multi_representation_map_from_df(
             or the length of ``source_cls``/``target_cls`` does not match
             the number of source/target columns.
         TypeError: If non-string data is found in source/target columns.
-        ValidationError: If ``id``/``name`` resolve to an empty string — see
-            :mod:`tidysdmx.artefact_validation`.
+        ValidationError: If ``id``/``name`` are omitted or empty (rules
+            M001/M003) — see :mod:`tidysdmx.artefact_validation`.
     """
     if df.empty:
         raise ValueError("Input DataFrame cannot be empty.")
@@ -740,10 +777,12 @@ def build_multi_representation_map_from_df(
         if (generate_urn and id)
         else None
     )
+    # None -> "" so omitted id/name fail the value builder's publish-readiness
+    # checks (M001/M003) instead of typeguard's stricter `str` annotation.
     return _build_multi_representation_map(
-        id=id,
+        id=id or "",
         agency=agency,
-        name=name,
+        name=name or "",
         source=[_resolve_representation_ref(s) for s in source_cls]
         if source_cls
         else [str(DataType.STRING)] * len(_source_cols),
@@ -759,10 +798,43 @@ def build_multi_representation_map_from_df(
 
 @deprecated(replacement="build_multi_representation_map_from_df")
 def build_multi_representation_map(
-    *args: object, **kwargs: object
+    df: pd.DataFrame,
+    agency: str = "FAKE_AGENCY",
+    id: str | None = None,
+    name: str | None = None,
+    source_cls: list[str] | None = None,
+    target_cls: list[str] | None = None,
+    version: str = "1.0",
+    description: str | None = None,
+    source_cols: list[str] | None = None,
+    target_cols: list[str] | None = None,
+    valid_from_col: str = "valid_from",
+    valid_to_col: str = "valid_to",
+    generate_urn: bool = True,
+    default_value: str | None = None,
 ) -> MultiRepresentationMap:
-    """Deprecated alias for :func:`build_multi_representation_map_from_df`."""
-    return build_multi_representation_map_from_df(*args, **kwargs)
+    """Deprecated alias for :func:`build_multi_representation_map_from_df`.
+
+    Mirrors that function's signature so ``help()``/IDE introspection keep
+    showing the real parameters during the deprecation window; see it for
+    the full documentation.
+    """
+    return build_multi_representation_map_from_df(
+        df,
+        agency=agency,
+        id=id,
+        name=name,
+        source_cls=source_cls,
+        target_cls=target_cls,
+        version=version,
+        description=description,
+        source_cols=source_cols,
+        target_cols=target_cols,
+        valid_from_col=valid_from_col,
+        valid_to_col=valid_to_col,
+        generate_urn=generate_urn,
+        default_value=default_value,
+    )
 
 
 @typechecked

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 from collections.abc import Sequence
 from datetime import UTC, datetime
@@ -879,6 +880,14 @@ class TestBuildRepresentationMapFromDf:
                 name="Ctry",
             )
 
+    def test_missing_id_name_raises_validation_error(self):
+        """A valid frame without id/name -> M001/M003 -> ValidationError."""
+        from tidysdmx.artefact_validation import ValidationError
+
+        df = pd.DataFrame({"source": ["BE"], "target": ["BEL"]})
+        with pytest.raises(ValidationError, match=r"(?s)\[M001\].*\[M003\]"):
+            build_representation_map_from_df(df, agency="ECB")
+
     def test_deprecated_shim_warns(self):
         """The old structures.build_representation_map name warns, naming itself."""
         import tidysdmx.structures as s
@@ -888,6 +897,13 @@ class TestBuildRepresentationMapFromDf:
             FutureWarning, match=r"build_representation_map is deprecated"
         ):
             s.build_representation_map(df, agency="ECB", id="RM1", name="Ctry")
+
+    def test_deprecated_shim_preserves_signature(self):
+        """The shim exposes the adapter's real parameters, not *args/**kwargs."""
+        import tidysdmx.structures as s
+
+        params = inspect.signature(s.build_representation_map).parameters
+        assert list(params)[:4] == ["df", "agency", "id", "name"]
 
 
 class TestBuildSingleComponentMap:
@@ -1026,6 +1042,19 @@ class TestBuildSingleComponentMap:
         assert maps[-1].source == "regex:.*"
         assert maps[-1].target == "_Z"
 
+    def test_build_single_component_map_missing_id_name_raises_validation_error(
+        self, value_map_df_mandatory_cols
+    ):
+        """Omitted id/name propagate M001/M003 from the embedded rep map."""
+        from tidysdmx.artefact_validation import ValidationError
+
+        with pytest.raises(ValidationError, match=r"(?s)\[M001\].*\[M003\]"):
+            build_single_component_map(
+                value_map_df_mandatory_cols,
+                source_component="COUNTRY",
+                target_component="COUNTRY",
+            )
+
 
 class TestBuildMultiRepresentationMap:
     """Tests for the build_multi_representation_map function."""
@@ -1162,6 +1191,13 @@ class TestBuildMultiRepresentationMap:
                 sample_df, target_cls=["urn:a:cl", "urn:b:cl"]
             )
 
+    def test_missing_id_name_raises_validation_error(self, sample_df):
+        """A valid frame without id/name -> M001/M003 -> ValidationError."""
+        from tidysdmx.artefact_validation import ValidationError
+
+        with pytest.raises(ValidationError, match=r"(?s)\[M001\].*\[M003\]"):
+            build_multi_representation_map_from_df(sample_df, agency="ECB")
+
     def test_deprecated_shim_warns(self, sample_df):
         """The old structures.build_multi_representation_map name warns."""
         import tidysdmx.structures as s
@@ -1172,6 +1208,13 @@ class TestBuildMultiRepresentationMap:
             s.build_multi_representation_map(
                 sample_df, agency="ECB", id="MRM1", name="Ctry"
             )
+
+    def test_deprecated_shim_preserves_signature(self):
+        """The shim exposes the adapter's real parameters, not *args/**kwargs."""
+        import tidysdmx.structures as s
+
+        params = inspect.signature(s.build_multi_representation_map).parameters
+        assert list(params)[:4] == ["df", "agency", "id", "name"]
 
 
 class TestBuildMultiComponentMap:


### PR DESCRIPTION
The *_from_df rep-map adapters accept optional id/name but delegated them straight to the @typechecked value builders, so omitting them on a valid frame raised typeguard's TypeCheckError instead of the documented ValidationError. Coerce None to "" so the publish-readiness rules M001/M003 report them consistently (also via build_single_component_map and build_multi_component_map), and give the deprecated rep-map shims their real signatures so help()/IDE introspection keeps working during the migration window.

Addresses the Copilot review comments on PR #234.


Claude-Session: https://claude.ai/code/session_01SvPutPaaXXrSFH3HTCiZyj