### PR TITLE
docs: fix docs-site link and define tidy_raw_df in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pip install tidysdmx
 ## Quick start
 
 ```python
+import pandas as pd
 import pysdmx as px
 from tidysdmx import (
     parse_mapping_template_wb,
@@ -46,7 +47,8 @@ sm = build_structure_map_from_template_wb(
     source_structure_id="WB.DP:DP_SCHEMA(1.0)",
 )
 
-# 3. Map your tidy data and validate the output
+# 3. Load your tidy data, map it, and validate the output
+tidy_raw_df = pd.read_csv("my_tidy_data.csv")
 mapped = map_structures(df=tidy_raw_df, structure_map=sm)
 out = standardize_output(
     df=mapped, artefact_id="WB.GGH.HSP:DS_ASPIRE(1.0.0)",
@@ -74,7 +76,7 @@ errors = validate_dataset_local(df=out, schema=dis_schema)
 ## Documentation
 
 Full documentation, including the user guide and API reference, is published at the
-[tidysdmx docs site](https://github.com/WB-DECIS/tidysdmx).
+[tidysdmx docs site](https://wb-decis.github.io/tidysdmx/).
 
 ## Contributing
 

--- a/index.qmd
+++ b/index.qmd
@@ -14,6 +14,7 @@ pip install tidysdmx
 ```
 
 ```python
+import pandas as pd
 import pysdmx as px
 from tidysdmx import (
     create_schema_from_table,
@@ -39,7 +40,8 @@ sm = build_structure_map_from_template_wb(
     source_structure_id="WB.DP:DP_SCHEMA(1.0)",
 )
 
-# 3. Map your tidy data and validate the output
+# 3. Load your tidy data, map it, and validate the output
+tidy_raw_df = pd.read_csv("my_tidy_data.csv")
 mapped = map_structures(df=tidy_raw_df, structure_map=sm)
 out = standardize_output(df=mapped, artefact_id="WB.GGH.HSP:DS_ASPIRE(1.0.0)",
                         schema=dis_schema, action="I")


### PR DESCRIPTION
Addresses the two Copilot review comments on PR #237:

- README's "tidysdmx docs site" link pointed at the GitHub repo; point it at the GitHub Pages site declared as the Documentation URL in pyproject.toml.
- The quick-start snippet used tidy_raw_df without defining it, so a copy/paste run failed with NameError. Add `import pandas as pd` and a `pd.read_csv("my_tidy_data.csv")` placeholder so the input DataFrame's origin is explicit. Apply the same fix to index.qmd, the docs landing page the README snippet was ported from.


Claude-Session: https://claude.ai/code/session_013zvnCuxJy39QLBiP5tfVdJ